### PR TITLE
General purpose screen builder

### DIFF
--- a/SupposeMVC.pro.user
+++ b/SupposeMVC.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.6.1, 2018-07-13T19:01:52. -->
+<!-- Written by QtCreator 4.6.1, 2018-07-18T13:07:38. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/generalpurposescreenbuilder.cpp
+++ b/generalpurposescreenbuilder.cpp
@@ -108,7 +108,10 @@ GeneralPurposeScreenBuilder::GeneralPurposeScreenBuilder(QString keywordExtensio
                 else if(fieldType == "noInput")
                 {
                     qDebug() << "noInput";
-                    dynamBody->addRow(new QLabel("\t\t\t\t"));
+                    if(fieldDescription.contains(QRegularExpression("\\w")))
+                        dynamBody->addRow(new QLabel(fieldDescription));
+                    else
+                        dynamBody->addRow(new QLabel("\t\t\t\t"));
                     fieldDescription.clear();
                     fieldAdded = true;
                 }
@@ -129,6 +132,9 @@ GeneralPurposeScreenBuilder::GeneralPurposeScreenBuilder(QString keywordExtensio
             }
             else if(!line.contains("{") && inField && currentField->contains("listButton", Qt::CaseInsensitive) && valid)/*7*/
             {/*7*/   // read lines that fill QComboxBox, place them in QStringList
+                if(line.contains(QRegularExpression("\\w")))
+                    while(line.at(0) == " ")
+                        line.remove(0, 1);
                 if(line.contains("}"))/*7*/
                 {
                     inField = false;
@@ -145,8 +151,6 @@ GeneralPurposeScreenBuilder::GeneralPurposeScreenBuilder(QString keywordExtensio
                         }
                         else if(line.contains(QRegularExpression("\\w")))
                         {
-                            while(line.at(0) == " ")
-                                line.remove(0, 1);
                             comboBoxProperties.append(line);
                             qDebug() << *currentField << "inField:" << line;
                         }
@@ -377,7 +381,7 @@ GeneralPurposeScreenBuilder::GeneralPurposeScreenBuilder(QString keywordExtensio
                     QStringList boxProperties = value.split(" ");
                     qDebug() << "default number box amount altered to " + boxProperties.at(0);
                     if(boxProperties.at(0) != "blank")
-                    tempLineEdit->setText(boxProperties.at(0));
+                        tempLineEdit->setText(boxProperties.at(0));
                     // Defines textbox to limit user input to numbers, with customized Lowest and Highest
                     if(boxProperties.size() > 2)
                     {

--- a/generalpurposescreenbuilder.cpp
+++ b/generalpurposescreenbuilder.cpp
@@ -376,11 +376,12 @@ GeneralPurposeScreenBuilder::GeneralPurposeScreenBuilder(QString keywordExtensio
                 {
                     QStringList boxProperties = value.split(" ");
                     qDebug() << "default number box amount altered to " + boxProperties.at(0);
+                    if(boxProperties.at(0) != "blank")
                     tempLineEdit->setText(boxProperties.at(0));
                     // Defines textbox to limit user input to numbers, with customized Lowest and Highest
                     if(boxProperties.size() > 2)
                     {
-                        QDoubleValidator *custom = new QDoubleValidator(QString(boxProperties.at(1)).toInt(), QString(boxProperties.at(2)).toInt(), 10 - QString(boxProperties.at(2)).toInt());
+                        QDoubleValidator *custom = new QDoubleValidator(QString(boxProperties.at(1)).toDouble(), QString(boxProperties.at(2)).toDouble(), 10 - QString(boxProperties.at(2)).size());
                         custom->setNotation(QDoubleValidator::StandardNotation);
                         tempLineEdit->setValidator(custom);
                         tempLineEdit->setObjectName(QString::number(dynamLineEdits.size()));
@@ -408,7 +409,7 @@ GeneralPurposeScreenBuilder::GeneralPurposeScreenBuilder(QString keywordExtensio
                         // Defines textbox to limit user input to numbers, with customized Lowest and Highest
                         QValidator *custom;
                         if(*currentField == "numberBox" || QString(boxProperties.at(1)).contains("."))
-                            custom = new QDoubleValidator(QString(boxProperties.at(1)).toInt(), QString(boxProperties.at(2)).toInt(), 10 - QString(boxProperties.at(2)).size());
+                            custom = new QDoubleValidator(QString(boxProperties.at(1)).toDouble(), QString(boxProperties.at(2)).toDouble(), 10 - QString(boxProperties.at(2)).size());
                         else
                             custom = new QIntValidator(QString(boxProperties.at(1)).toInt(), QString(boxProperties.at(2)).toInt());
                         tempLineEdit->setValidator(custom);
@@ -562,7 +563,7 @@ void GeneralPurposeScreenBuilder::inputMod(QString lineEditValue)
         qDebug() << "User Input:" << userInput;
         if(userInput > high)
         {
-            qDebug() << "Too high";
+            qDebug() << "User input of" << userInput << "is higher than" << high;
             dynamLineEdits.value(lineEditNum)->setText(QString::number(high));
         }
         else if(userInput <= high && userInput >= low)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -217,7 +217,7 @@ void MainWindow::readSectionToLists(QStringList *mainSectionText, QStringList *d
             if(variantList.contains(*variant))
                 descriptionBegin = i++;
         }
-        if(descriptionBegin > 0 && descriptionEnd < 0)
+        if(descriptionBegin >= 0 && descriptionEnd < 0)
             description->append(mainSectionText->at(i));
         if(QString(mainSectionText->at(i)).contains('}') && descriptionBegin > 0 && descriptionEnd < 0)
             descriptionEnd = i;
@@ -228,7 +228,8 @@ void MainWindow::readSectionToLists(QStringList *mainSectionText, QStringList *d
         mainSectionText->removeAt(i);
     mainSectionText->removeAll(QString("")); // removes spaces
     for (int i = 0; i < description->size(); ++i) {
-        if(QString(description->at(i)).contains("description:")) description->replace(i, QString(description->at(i)).remove("description:"));
+        if(description->at(i) == "description:" || description->at(i) == "description:{\\") description->removeAt(i);
+        else if(QString(description->at(i)).contains("description:")) description->replace(i, QString(description->at(i)).remove("description:"));
         if(QString(description->at(i)).contains("{")) description->replace(i, QString(description->at(i)).remove("{"));
         if(QString(description->at(i)).contains("}")) description->replace(i, QString(description->at(i)).remove("}"));
     }


### PR DESCRIPTION
 GPSB error catches:
1) added noInput description functionality
2) altered space removal in listButtons to account for designated selection
3) caught error if keyword description starts at line 0
4) caught alternate parm description label
5) caught blank literal
6) caught int instead of double error 