### PR TITLE
General purpose screen builder

### DIFF
--- a/SupposeMVC.pro.user
+++ b/SupposeMVC.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.6.1, 2018-08-27T09:51:31. -->
+<!-- Written by QtCreator 4.6.1, 2018-08-31T19:09:16. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/generalpurposescreenbuilder.cpp
+++ b/generalpurposescreenbuilder.cpp
@@ -423,6 +423,10 @@ GeneralPurposeScreenBuilder::GeneralPurposeScreenBuilder(QString keywordExtensio
                 else if((currentField->contains("numberBox", Qt::CaseInsensitive) || currentField->contains("sliderBox", Qt::CaseInsensitive)) && valid)
                 {// sliderBox functionality has been merged with the various numberBoxes
                     QStringList boxProperties = value.split(" ");
+                    if(boxProperties.contains("Fmax"))
+                        for(int i = 0; i < boxProperties.size(); i++)
+                            if(boxProperties.at(i).contains("Fmax"))
+                                boxProperties.replace(i, "2147483647");
                     QValidator *custom;
                     if(boxProperties.at(0) != "blank")
                     {
@@ -437,15 +441,15 @@ GeneralPurposeScreenBuilder::GeneralPurposeScreenBuilder(QString keywordExtensio
                             custom = new QIntValidator(QString(boxProperties.at(1)).toInt(), QString(boxProperties.at(2)).toInt());
                         else
                         {
-                            custom = new QDoubleValidator(QString(boxProperties.at(1)).toDouble(), QString(boxProperties.at(2)).toDouble(), 10 - QString(boxProperties.at(2)).size());
-                            custom->setProperty("setNotation", QDoubleValidator::StandardNotation);
+                            custom = new QDoubleValidator(QString(boxProperties.at(1)).toDouble(), QString(boxProperties.at(2)).toDouble(), 9 - QString(boxProperties.at(2)).size());
+                            custom->setProperty("notation", QDoubleValidator::StandardNotation);
                         }
                     }
                     else
                     {
                         // Default definition textbox to limit user input to numbers, if Lowest and Highest unspecified in parm file
                         if(currentField->contains("int"))
-                            custom = new QIntValidator(-999999999, 9999999999);
+                            custom = new QIntValidator(-2147483648, 2147483647);
                         else
                         {
                             custom = new QDoubleValidator(-9999999.9, 99999999.9, 9);
@@ -476,9 +480,18 @@ GeneralPurposeScreenBuilder::GeneralPurposeScreenBuilder(QString keywordExtensio
     QFormLayout *layout = new QFormLayout;
     layout->addRow(name, title);
     extensionKeyword->setLayout(layout);
+
+    // Creates scroll area (https://forum.qt.io/topic/31890/solved-layout-with-scrollbar/8)
+    QScrollArea *scrollArea = new QScrollArea;
+    scrollArea->setHorizontalScrollBarPolicy (Qt::ScrollBarAsNeeded);
+    scrollArea->setVerticalScrollBarPolicy (Qt::ScrollBarAsNeeded);
+    scrollArea->setWidgetResizable (true);
+    scrollArea->setWidget(dynamBodyHolder); // adds dynamically created body to scroll area
+
     mainLayout = new QGridLayout;
     mainLayout->addWidget(extensionKeyword, 0, 0);
-    mainLayout->addWidget(dynamBodyHolder, 3, 0);
+    mainLayout->addWidget(scrollArea, 2, 0);
+//    mainLayout->addWidget(dynamBodyHolder, 3, 0);
     mainLayout->addWidget(buttonBox, 4, 0);
     acceptButton->setFont(*font);
     cancelButton->setFont(*font);

--- a/generalpurposescreenbuilder.h
+++ b/generalpurposescreenbuilder.h
@@ -26,8 +26,9 @@ class GeneralPurposeScreenBuilder : public QDialog
 public:
     GeneralPurposeScreenBuilder(QString keywordExtension, QStringList description, QStringList MSText, QString *variant, QMap<QString, QMap<QString, QString>> *speciesMSTAbbreviationName, QMap<QString, QString> *variantAbbreviationNames, int startYear, QWidget *parent = 0);
     bool addDynamComboBox(QStringList comboBoxProperties, QFormLayout *dynamBody, QLabel *tempLabel, QString fieldNum);
-//    bool variantListCheck(QString &line, QStringList &variantList, QString &fieldNum = null);
+    QString numberToQString(double number);
     ~GeneralPurposeScreenBuilder();
+
 private slots:
     void accept();
     void reset();

--- a/suppose.prm
+++ b/suppose.prm
@@ -27114,22 +27114,22 @@ Mountain hemlock}
 speciesCode{wc pn}:{ALL AF RF LP DF WH MH}
 
 f3:{intNumberBox Cutting preference corresponding to DMR = 1}
-f3v:0
+f3v:{0}
 
 f4:{intNumberBox Cutting preference corresponding to DMR = 2}
-f4v:0
+f4v:{0}
 
 f5:{intNumberBox Cutting preference corresponding to DMR = 3}
-f5v:0
+f5v:{0}
 
 f6:{intNumberBox Cutting preference corresponding to DMR = 4}
-f6v:4000
+f6v:{4000}
 
 f7:{intNumberBox Cutting preference corresponding to DMR = 5}
-f7v:5000
+f7v:{5000}
 
 f8:{intNumberBox Cutting preference corresponding to DMR = 6}
-f8v:6000
+f8v:{6000}
 
 answerForm:{\
 MistPref  !1,10!!2,10,speciesCode!


### PR DESCRIPTION

Added catch for Fmax, scroll area to GPSB, tool tip pop-up, numberToQString(), caught prm file inconsistancies, Merged int and double validators

The merge of the int and double validators with scientific notation allows for users to input many digits that will be inspected after focus is lost.

The tooltip displays the numeric bounds required for a given number box.

The number to string conversion function also truncates meaningless zeroes.