### PR TITLE
+editingFinished, improved: inputErrorAlert, titleVar, noInput, variantListCheck()

### DIFF
--- a/SupposeMVC.pro.user
+++ b/SupposeMVC.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.6.1, 2018-08-31T19:09:16. -->
+<!-- Written by QtCreator 4.6.1, 2018-09-10T12:11:55. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>


### PR DESCRIPTION
InputErrorAlert now ignores being emitted more than once (only executes if input string does not contain "Input bound from ").

A listener for editingFinished() on numberBoxes has been added, which calls modifyInput() (only when correct).

Improved: title & titleVar, noInput, variantListCheck().