### PR TITLE
+ FVSkeyword Accept & lineEdit functionality, + bug fixes

### DIFF
--- a/SupposeMVC.pro.user
+++ b/SupposeMVC.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.6.1, 2018-09-11T13:14:39. -->
+<!-- Written by QtCreator 4.6.1, 2018-09-13T17:03:24. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -37,7 +37,7 @@ MainWindow::MainWindow(QWidget *parent) :
             {
                 QMap<QString, QString> *habitatPlantNumberAbbreviation = new QMap<QString, QString>;
                 qDebug() << ++habPa << MainSectionText << "at position" << parmMainSectionMap.value(MainSectionText);
-                makeDictionaryFromSection(habitatPlantNumberAbbreviation, readSectionFromMappedLoc(*parameters, parmMainSectionMap.value(MainSectionText)), QRegularExpression(":{"));
+                makeDictionaryFromSection(habitatPlantNumberAbbreviation, readSectionFromMappedLoc(*parameters, parmMainSectionMap.value(MainSectionText)), QRegularExpression("({blank})?:{"));
                 habitatTypePlantAssociationMSTNumberAbbreviation.insert(MainSectionText, *habitatPlantNumberAbbreviation);
                 qDebug() << habitatTypePlantAssociationMSTNumberAbbreviation.value(MainSectionText).keys() <<(habitatTypePlantAssociationMSTNumberAbbreviation.value(MainSectionText).keys().size() - 1);
             }
@@ -45,7 +45,7 @@ MainWindow::MainWindow(QWidget *parent) :
             {
                 QMap<QString, QString> *forestNumberName = new QMap<QString, QString>;
                 qDebug() << ++forests << MainSectionText << "at position" << parmMainSectionMap.value(MainSectionText);
-                makeDictionaryFromSection(forestNumberName, readSectionFromMappedLoc(*parameters, parmMainSectionMap.value(MainSectionText)), QRegularExpression(":{"));
+                makeDictionaryFromSection(forestNumberName, readSectionFromMappedLoc(*parameters, parmMainSectionMap.value(MainSectionText)), QRegularExpression("({blank})?:{"));
                 forestMSTNumberName.insert(MainSectionText, *forestNumberName);
                 qDebug() << forestMSTNumberName.value(MainSectionText).keys() <<(forestMSTNumberName.value(MainSectionText).keys().size() - 1);
             }


### PR DESCRIPTION
Improved FVSKeyword Window user experience and added functionality ("Accept" button, selectKeyword now either finds keyword from input and opens the corresponding window or selects closest keyword), noInput count error fix, Forests_ dictionary send error fixes, "{blank}" catch for habPa & Forests dictionaries from parm file.