### PR TITLE
- Modality for VariantExtension & FVSKeywordsWindow, + setExtensionCa…

### DIFF
--- a/SupposeMVC.pro.user
+++ b/SupposeMVC.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.6.1, 2018-09-13T17:03:24. -->
+<!-- Written by QtCreator 4.6.1, 2018-09-17T16:03:02. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/fvskeywordswindow.cpp
+++ b/fvskeywordswindow.cpp
@@ -13,6 +13,26 @@ FVSKeywordsWindow::FVSKeywordsWindow(QMap<QString, qint64> *parmMainSectionMap, 
     varExten = MainWindow::variantExtensions;
     keyword_E_MST = &(MainWindow::keyword_Exten_MainSecTitle);
     extenAbbrevName = MainWindow::extensionAbbreviationNames;
+    setExtensionCategoryKeywordModels();
+}
+
+FVSKeywordsWindow::~FVSKeywordsWindow()
+{
+    delete extensionCategoryKeywords;
+    delete categoryAbbreviationNames;
+    delete extensionCategories;
+    delete keywordDictionary;
+    delete keywordExtension;
+    delete categoryKeywords;
+    delete extensionsModel;
+    delete categoriesModel;
+    delete keywordsModel;
+    delete extensions;
+    delete ui;
+}
+
+void FVSKeywordsWindow::setExtensionCategoryKeywordModels()
+{
     extensions = new QStringList();
     keywordsModel = new QStringListModel(this);
     extensionsModel = new QStringListModel(this);
@@ -31,12 +51,12 @@ FVSKeywordsWindow::FVSKeywordsWindow(QMap<QString, qint64> *parmMainSectionMap, 
 //    extensionsModel->sort(0);
     categoryAbbreviationNames = new QMap<QString, QString>;
     categoryAbbreviationNames->insert("all", "All keywords");
-    MainWindow::makeDictionaryFromSection(categoryAbbreviationNames, MainWindow::readSectionFromMappedLoc(*parameters, qint64(parmMap->value("keyword_categories"))));
+    MainWindow::makeDictionaryFromSection(categoryAbbreviationNames, MainWindow::readSectionFromMappedLoc(*parm, qint64(parmMap->value("keyword_categories"))));
     extensionCategories = new QMap<QString, QStringList>;
     categoryKeywords = new QMap<QString, QString/*List*/>;
     keywordDictionary = new QMap<QString, QMap<QString, QString>>;
     keywordExtension = new QMap<QString, QString>;
-    QStringList keywordListRaw = MainWindow::readSectionFromMappedLoc(*parameters, qint64(parmMap->value("keyword_list")));
+    QStringList keywordListRaw = MainWindow::readSectionFromMappedLoc(*parm, qint64(parmMap->value("keyword_list")));
     QStringList keywordExtensionCategories, extenCatetemp;
     bool midKeywordDefinition = false;
     bool strpToDo = false;
@@ -185,21 +205,6 @@ FVSKeywordsWindow::FVSKeywordsWindow(QMap<QString, qint64> *parmMainSectionMap, 
     ui->extension_listView->setModel(extensionsModel);
     ui->extension_listView->setCurrentIndex(extensionsModel->index(0));
     ui->extension_listView->clicked(extensionsModel->index(0));
-}
-
-FVSKeywordsWindow::~FVSKeywordsWindow()
-{
-    delete extensionCategoryKeywords;
-    delete categoryAbbreviationNames;
-    delete extensionCategories;
-    delete keywordDictionary;
-    delete extensionsModel;
-    delete categoriesModel;
-    delete keywordsModel;
-    delete extensions;
-//    delete categories;
-//    delete keywords;
-    delete ui;
 }
 
 void FVSKeywordsWindow::on_extension_listView_clicked(const QModelIndex &index)

--- a/fvskeywordswindow.h
+++ b/fvskeywordswindow.h
@@ -18,6 +18,7 @@ class FVSKeywordsWindow : public QDialog
 
 public:
     explicit FVSKeywordsWindow(QMap<QString, qint64> *parmMainSectionMap, QFile *parameters, QWidget *parent = 0);
+    void setExtensionCategoryKeywordModels();
     ~FVSKeywordsWindow();
 
 private slots:

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -69,12 +69,20 @@ MainWindow::MainWindow(QWidget *parent) :
     }
     else
         qDebug() << "CRITICAL ERROR: Mapping Unsuccessful!";
+    FVSAddKeywordsWindow = new FVSKeywordsWindow(&parmMainSectionMap, parameters, this);
+    selectVariantExtensionWindow = new VariantExtension(variant, variantExtensions, variantAbbreviationNames, extensionAbbreviationNames, &variantLocked);
+    selectVariantExtensionWindow->setWindowTitle("Select Variant and Extension");
+//    connect(selectVariantExtensionWindow, SIGNAL(accepted()), this, SLOT(on_button_SelectModifiers_clicked()));
+    connect(selectVariantExtensionWindow, &VariantExtension::variantChanged, [=](){FVSAddKeywordsWindow->setExtensionCategoryKeywordModels(); FVSAddKeywordsWindow->update();}); // potentially for every selection
+    connect(selectVariantExtensionWindow, &QDialog::accepted, [=](){selectVariantExtensionWindow->startingVariant = *variant;}); // for window close only
 }
 
 MainWindow::~MainWindow()
 {
+    delete selectVariantExtensionWindow;
     delete extensionAbbreviationNames;
     delete variantAbbreviationNames;
+    delete FVSAddKeywordsWindow;
     delete variantExtensions;
     delete preferences;
     delete parameters;
@@ -166,6 +174,8 @@ bool MainWindow::mapParmsMainSectionText()
 void MainWindow::on_button_Exit_clicked()
 {
     qDebug() << "Exit Button clicked.";
+    selectVariantExtensionWindow->close();
+    FVSAddKeywordsWindow->close();
     this->close();
 }
 
@@ -307,8 +317,10 @@ void MainWindow::on_button_SelectOutputs_clicked()
 void MainWindow::on_button_AddKeywords_clicked()
 {
     qDebug() << "Add Keywords Button clicked";
-    FVSKeywordsWindow FVSAddKeywordsWindow(&parmMainSectionMap, parameters, this);
-    FVSAddKeywordsWindow.exec();
+    /*FVSKeywordsWindow FVSAddKeywordsWindow(&parmMainSectionMap, parameters, this);
+    FVSAddKeywordsWindow.exec();*/ // for modal
+    FVSAddKeywordsWindow->show(); // for modeless
+    FVSAddKeywordsWindow->activateWindow();
 }
 
 void MainWindow::on_button_InsertFromFile_clicked()
@@ -329,7 +341,9 @@ void MainWindow::on_button_SelectModifiers_clicked()
 void MainWindow::on_actionSelect_Variant_and_Extension_triggered()
 {
     qDebug() << "Select Variant and Extension clicked";
-    VariantExtension selectVariantExtensionWindow(variant, variantExtensions, variantAbbreviationNames, extensionAbbreviationNames, &variantLocked);
+    /*VariantExtension selectVariantExtensionWindow(variant, variantExtensions, variantAbbreviationNames, extensionAbbreviationNames, &variantLocked);
     selectVariantExtensionWindow.setWindowTitle("Select Variant and Extension");
-    selectVariantExtensionWindow.exec();
+    selectVariantExtensionWindow.exec();*/
+    selectVariantExtensionWindow->show(); // modeless
+    selectVariantExtensionWindow->activateWindow();
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -20,6 +20,10 @@ namespace Ui {
 class MainWindow;
 }
 
+class FVSKeywordsWindow; // forward declaration
+class VariantExtension; // forward declaration
+
+
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -69,6 +73,8 @@ private slots:
 
 private:
     Ui::MainWindow *ui;
+    FVSKeywordsWindow *FVSAddKeywordsWindow;
+    VariantExtension *selectVariantExtensionWindow;
 };
 
 #endif // MAINWINDOW_H

--- a/variantextension.cpp
+++ b/variantextension.cpp
@@ -11,6 +11,7 @@ VariantExtension::VariantExtension(QString *variant, QMap<QString, QString> *var
     variantModel = new QStringListModel;
     programModel = new QStringListModel;
     extensionModel = new QStringListModel;
+    startingVariant = *variant;
     variantFVS = variant;
     locked = variantLocked;
     QStringList fvsPrograms;
@@ -68,6 +69,7 @@ void VariantExtension::on_comboBox_variant_activated(const QString &arg1)
     ui->comboBox_program->setCurrentText(programVariant->key(variantAbbreviationNamesMap->key(arg1)));
     qDebug() << "Variant: " + variantAbbreviationNamesMap->value(variantAbbreviationNamesMap->key(ui->comboBox_variant->currentText())) + " (" +variantAbbreviationNamesMap->key(ui->comboBox_variant->currentText()) + ") selected.";
     *variantFVS = variantAbbreviationNamesMap->key(ui->comboBox_variant->currentText());
+//    emit variantChanged(); // FVS reconstruction for every selection
     QStringList FVSExtensionsFull, FVSExtensionsAbbrev = QString(programExtensions->value(programVariant->key(variantAbbreviationNamesMap->key(arg1)))).split(" ");
 //     qDebug() << FVSExtensionsAbbrev;
     FVSExtensionsFull.append(extensionAbbreviationNamesMap->value("base"));
@@ -97,6 +99,9 @@ void VariantExtension::on_pushButton_lock_clicked()
 
 void VariantExtension::on_pushButton_close_clicked()
 {
-    qDebug() << "VariantExtension::Close clicked\n";
-    this->close();
+    qDebug() << "VariantExtension::Close clicked\n" << startingVariant << *variantFVS;
+//    this->close();
+    if(startingVariant != *variantFVS)
+        emit variantChanged();
+    this->accept();
 }

--- a/variantextension.h
+++ b/variantextension.h
@@ -17,16 +17,20 @@ class VariantExtension : public QDialog
 
 public:
     explicit VariantExtension(QString *variant, QMap<QString, QString> *variantExtensions, QMap<QString, QString> *variantAbbreviationNames, QMap<QString, QString> *extensionAbbreviationNames, bool *variantLocked, QWidget *parent = 0);
+    QString startingVariant;
     ~VariantExtension();
+
+signals:
+    void variantChanged();
 
 private slots:
     void on_comboBox_variant_activated(const QString &arg1);
 
     void on_comboBox_program_activated(const QString &arg1);
 
-    void on_pushButton_lock_clicked();
-
     void on_pushButton_close_clicked();
+
+    void on_pushButton_lock_clicked();
 
 private:
     bool *locked;


### PR DESCRIPTION
…tegoryKeywordModels()

Removed modality for VariantExtension and FVSKeywords windows, moved constructor code in FVSKeywordWindow pertaining to extension, category, and keyword models into the separate function setExtensionCategoryKeywordModels() so it can be lists can be reset when the variant is changed.