### PR TITLE
+ parent integration to GPSB warning window, default parmMap result

### DIFF
--- a/SupposeMVC.pro.user
+++ b/SupposeMVC.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.6.1, 2018-09-18T10:36:47. -->
+<!-- Written by QtCreator 4.6.1, 2018-10-01T15:24:02. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/fvskeywordswindow.cpp
+++ b/fvskeywordswindow.cpp
@@ -294,9 +294,9 @@ void FVSKeywordsWindow::on_keyword_listView_doubleClicked(const QModelIndex &ind
     }
     description->clear();
     mainSectionText->clear();
-    qDebug() << keyword <<  parmMap->value(keyword_E_MST->value(keyword).value(extensionTemp));
+    qDebug() << keyword <<  parmMap->value(keyword_E_MST->value(keyword).value(extensionTemp), -1);
     GeneralPurposeScreenBuilder *dynamWin;
-    if(parmMap->value(keyword_E_MST->value(keyword).value(extensionTemp)) > 0)
+    if(parmMap->value(keyword_E_MST->value(keyword).value(extensionTemp), -1) >= 0)
     {
         *mainSectionText = MainWindow::readSectionFromMappedLoc(*parm, parmMap->value(keyword_E_MST->value(keyword).value(extensionTemp)));
         MainWindow::readSectionToLists(mainSectionText, description);
@@ -309,7 +309,7 @@ void FVSKeywordsWindow::on_keyword_listView_doubleClicked(const QModelIndex &ind
         }
     }
     else
-        dynamWin = new GeneralPurposeScreenBuilder("Warning!", "The " + keyword + " keyword is not yet supported.");
+        dynamWin = new GeneralPurposeScreenBuilder("Warning!", "The " + keyword + " keyword is not yet supported.", this);
     dynamWin->exec();
     dynamWin->deleteLater();
 }

--- a/generalpurposescreenbuilder.cpp
+++ b/generalpurposescreenbuilder.cpp
@@ -115,6 +115,8 @@ GeneralPurposeScreenBuilder::GeneralPurposeScreenBuilder(QString windowTitle, QS
     rectGPSB.setHeight((mainLayout->sizeHint().height() * 1.1 < screenActual.height()*0.9) ? (mainLayout->sizeHint().height() * 1.1):(screenActual.height()*0.9));
     this->setGeometry(rectGPSB);
     this->setGeometry(QStyle::alignedRect(Qt::LeftToRight, Qt::AlignCenter, this->size(), screenActual)); // centers window (http://doc.qt.io/qt-5/qstyle.html#alignedRect, https://wiki.qt.io/How_to_Center_a_Window_on_the_Screen)
+    if(parent) // centers window on parent if given
+        this->move(parent->pos().x()+parent->width()/2-this->width()/2, parent->pos().y()+parent->height()/2-this->height()/2);
 }
 
 GeneralPurposeScreenBuilder::GeneralPurposeScreenBuilder(QString keywordExtension, QStringList description, QStringList MSText, QString *variant, QMap<QString, QMap<QString, QString>> *mainSectionTextDictionary, int startYear, QWidget *parent) : QDialog(parent)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -177,7 +177,7 @@ bool MainWindow::mapParmsMainSectionText()
 void MainWindow::on_button_Exit_clicked()
 {
     qDebug() << "Main Window Exit Button clicked.";
-    GeneralPurposeScreenBuilder *warningWindow = new GeneralPurposeScreenBuilder("Warning!", "Are you sure you want to exit Suppose?");
+    GeneralPurposeScreenBuilder *warningWindow = new GeneralPurposeScreenBuilder("Warning!", "Are you sure you want to exit Suppose?", this);
     warningWindow->setFixedSize(warningWindow->size());
     warningWindow->exec();
     bool close = warningWindow->result();

--- a/managementactions.cpp
+++ b/managementactions.cpp
@@ -171,7 +171,14 @@ void ManagementActions::on_ManagmentActions_listView_clicked(const QModelIndex &
             qDebug() << "Window: " << managementTitle;
             if(!(managementTitle.contains("Plant") || managementTitle.contains("Thin")))
             {
-                qDebug() << "Management Title: " << managementTitle;
+                if(parmMap->value("management." + managementTitle, -1) >= 0)
+                {
+                    qDebug() << "Management Title: " << managementTitle << "at file location:" << parmMap->value("management." + managementTitle, -1);
+                }
+                else if(parmMap->value("management." + actionName, -1) >= 0)
+                {
+                    qDebug() << "Management Title: " << actionName << "at file location:" << parmMap->value("management." + actionName, -1);
+                }
             }
             else if(managementTitle.contains("Plant"))
             {


### PR DESCRIPTION
When a window is passed into the GPSB warning window constructor, it will now center itself on the parent.  If no parent is passed into the GPSB window it defaults to the center of the screen.

When a Main Section Title is looked up in the parmMap, a default of -1 is passed in to ensure that any result >= 0 works.